### PR TITLE
Allow config max_size for syslog message

### DIFF
--- a/lib/fluentd/plugin/out_syslog_buffered.rb
+++ b/lib/fluentd/plugin/out_syslog_buffered.rb
@@ -16,6 +16,7 @@ module Fluent
     config_param :severity, :string, :default => 'debug'
     config_param :use_record, :string, :default => nil
     config_param :payload_key, :string, :default => 'message'
+    config_param :max_size, :integer, :default => 4096
 
 
     def initialize
@@ -41,6 +42,9 @@ module Fluent
       @payload_key = conf['payload_key']
       if not @payload_key
         @payload_key = "message"
+      end
+      if conf['max_size']
+        @max_size = conf['max_size'].to_i
       end
     end
 
@@ -115,7 +119,7 @@ module Fluent
         end
         if @socket
           begin
-            @socket.write packet.assemble + "\n"
+            @socket.write packet.assemble(@max_size) + "\n"
             @socket.flush
           rescue SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EPIPE, Timeout::Error, OpenSSL::SSL::SSLError => e
             log.warn "out:syslog: connection error by #{@remote_syslog}:#{@port} :#{e}"


### PR DESCRIPTION
This pull request makes the syslog message size a configurable parameter with a default of 4096 for TCP syslog.