### PR TITLE
Add config options to create json message for syslog using CEE protocol

### DIFF
--- a/lib/fluentd/plugin/out_syslog.rb
+++ b/lib/fluentd/plugin/out_syslog.rb
@@ -38,6 +38,7 @@ module Fluent
       @facilty = conf['facility']
       @severity = conf['severity']
       @use_record = conf['use_record']
+      @cee_record = conf['cee_record']
       @payload_key = conf['payload_key']
       if not @payload_key
         @payload_key = "message"
@@ -84,7 +85,11 @@ module Fluent
                               tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
                            end
         packet = @packet.dup
-        packet.content = record[@payload_key]
+        if @cee_record
+          packet.content = "@cee:" + record.to_json
+        else
+          packet.content = record[@payload_key]
+        end
         @socket.send(packet.assemble, 0, @remote_syslog, @port)
     }
     end

--- a/lib/fluentd/plugin/out_syslog_buffered.rb
+++ b/lib/fluentd/plugin/out_syslog_buffered.rb
@@ -16,6 +16,7 @@ module Fluent
     config_param :severity, :string, :default => 'debug'
     config_param :use_record, :string, :default => nil
     config_param :payload_key, :string, :default => 'message'
+    config_param :cee_record, :string, :default => nil
 
 
     def initialize
@@ -38,6 +39,7 @@ module Fluent
       @facilty = conf['facility']
       @severity = conf['severity']
       @use_record = conf['use_record']
+      @cee_record = conf['cee_record']
       @payload_key = conf['payload_key']
       if not @payload_key
         @payload_key = "message"
@@ -108,7 +110,11 @@ module Fluent
                            tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
                          end
       packet = @packet.dup
-      packet.content = record[@payload_key]
+      if @cee_record
+        packet.content = "@cee:" + record.to_json
+      else
+        packet.content = record[@payload_key]
+      end
       begin
         if not @socket
           @socket = create_tcp_socket(@remote_syslog, @port)


### PR DESCRIPTION
Adds a simple config parameter which treats the whole record as JSON and prepends "@cee: " to the content.

We are using the record transformer plugin to create JSON output and then we want to ship that output off to an rsyslog endpoint.  We don't want to select a field from the record and we want to treat the entire message as JSON so the ELK endpoint can index the fields.