### PR TITLE
Setting tag_key to a non-existing field causes a ruby error.

### DIFF
--- a/lib/fluentd/plugin/out_syslog.rb
+++ b/lib/fluentd/plugin/out_syslog.rb
@@ -78,11 +78,15 @@ module Fluent
           time = Time.now
         end
         @packet.time = time
-        @packet.tag      = if tag_key
-                              record[tag_key][0..31].gsub(/[\[\]]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
-                           else
-                              tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
-                           end
+        @packet.tag = if @tag_key
+                        begin
+                          record[@tag_key][0..31].gsub(/[\[\]]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+                        rescue
+                          tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+                        end
+                      else
+                          tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+                      end
         packet = @packet.dup
         packet.content = record[@payload_key]
         @socket.send(packet.assemble, 0, @remote_syslog, @port)

--- a/lib/fluentd/plugin/out_syslog_buffered.rb
+++ b/lib/fluentd/plugin/out_syslog_buffered.rb
@@ -102,11 +102,15 @@ module Fluent
         time = Time.now
       end
       @packet.time = time
-      @packet.tag      = if tag_key
-                           record[tag_key][0..31].gsub(/[\[\]]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
-                         else
-                           tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
-                         end
+      @packet.tag = if @tag_key
+                      begin
+                        record[@tag_key][0..31].gsub(/[\[\]]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+                      rescue
+                        tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+                      end
+                    else
+                        tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+                    end
       packet = @packet.dup
       packet.content = record[@payload_key]
       begin


### PR DESCRIPTION
Steps:
0) Configure fluent-plugin-remote-syslog.
1) Set "tag_key bogus" in the fluent-plugin-remote-syslog config file,
   where "bogus" is not a field of log messages.
2) Let fluentd process logs.

Result: Following error/stacktraces are logged.
 error_class="NoMethodError" error="undefined method `[]' for nil:NilClass"
 [warn]: /etc/fluent/plugin/out_syslog_buffered.rb:106:in `send_to_syslog'
 [warn]: /etc/fluent/plugin/out_syslog_buffered.rb:85:in `block in write'
 [warn]: /usr/share/gems/gems/fluentd/lib/fluent/plugin/buf_memory.rb:67:in `feed_each'
 [warn]: /usr/share/gems/gems/fluentd/lib/fluent/plugin/buf_memory.rb:67:in `msgpack_each'
 [warn]: /etc/fluent/plugin/out_syslog_buffered.rb:84:in `write'
 [warn]: /usr/share/gems/gems/fluentd/lib/fluent/buffer.rb:354:in `write_chunk'
 [warn]: /usr/share/gems/gems/fluentd/lib/fluent/buffer.rb:333:in `pop'
 [warn]: /usr/share/gems/gems/fluentd/lib/fluent/output.rb:342:in `try_flush'
 [warn]: /usr/share/gems/gems/fluentd/lib/fluent/output.rb:149:in `run'

Fix: Prepare "rescue" for the case the tag_key value is not a log field,
     i.e., record[@tag_key] is nil.